### PR TITLE
Develop

### DIFF
--- a/sacco_frontend/src/api/axios.ts
+++ b/sacco_frontend/src/api/axios.ts
@@ -6,7 +6,7 @@ import axios, {
 } from "axios";
 import Cookies from "js-cookie";
 
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8000/api/v1";
+const API_URL = import.meta.env.PROD ? "/api" : "http://localhost:8000/api";
 
 const axiosInstance: AxiosInstance = axios.create({
   baseURL: API_URL,


### PR DESCRIPTION
This pull request updates the API URL configuration in the `axios.ts` file to better handle production and development environments.

Environment-specific API URL configuration:

* [`sacco_frontend/src/api/axios.ts`](diffhunk://#diff-accb9de07c5755cbb91d2586ad7bc2a60f1bec2cbe061e6be6e86c53320f205cL9-R9): The `API_URL` constant now checks if `import.meta.env.PROD` is true to use a relative `/api` path for production, while retaining the `http://localhost:8000/api` URL for development.